### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/gyazowin/gyazowin.cpp
+++ b/gyazowin/gyazowin.cpp
@@ -860,7 +860,7 @@ BOOL uploadFile(HWND hwnd, LPCTSTR fileName)
 	HINTERNET hConnection = InternetConnect(hSession, 
 		UPLOAD_SERVER, INTERNET_DEFAULT_HTTP_PORT,
 		NULL, NULL, INTERNET_SERVICE_HTTP, 0, NULL);
-	if(NULL == hSession) {
+	if(NULL == hConnection) {
 		MessageBox(hwnd, _T("Cannot initiate connection"),
 			szTitle, MB_ICONERROR | MB_OK);
 		return FALSE;
@@ -870,7 +870,7 @@ BOOL uploadFile(HWND hwnd, LPCTSTR fileName)
 	HINTERNET hRequest    = HttpOpenRequest(hConnection,
 		_T("POST"), UPLOAD_PATH, NULL,
 		NULL, NULL, INTERNET_FLAG_DONT_CACHE | INTERNET_FLAG_RELOAD, NULL);
-	if(NULL == hSession) {
+	if(NULL == hRequest) {
 		MessageBox(hwnd, _T("Cannot compose post request"),
 			szTitle, MB_ICONERROR | MB_OK);
 		return FALSE;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

There are two errors (or misprints), you're checking **hSession** after calling InternetConnect and HttpOpenRequest in place of the checking of **hConnection** and **hRequest**.
Therefore, if there will be unavailable UPLOAD_SERVER (upload.gyazo.com) or if there will be failed post request to it (maybe wrong answer from this server), then you will get null hConnection and/or hRequest and the application will crashes.
Please, apply these changes, because it is real bug.

[V547](https://www.viva64.com/en/w/v547/) Expression '0 == hSession' is always false. gyazowin.cpp 863
[V547](https://www.viva64.com/en/w/v547/) Expression '0 == hSession' is always false. gyazowin.cpp 873
